### PR TITLE
Drupal7 base theme (node-sass)

### DIFF
--- a/d7/Dockerfile
+++ b/d7/Dockerfile
@@ -1,0 +1,46 @@
+FROM mhart/alpine-node:7
+
+VOLUME /work
+WORKDIR /work
+
+RUN apk add --no-cache make g++ git python && \
+    apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community libsass && \
+    npm --unsafe-perm install -g \
+        node-sass \
+        webpack@1 \
+        webpack-dev-server \
+        webpack-stream \
+        babel-core \
+        babel-loader \
+        babel-plugin-transform-runtime \
+        babel-polyfill \
+        babel-preset-es2015 \
+        breakpoint-sass \
+        chroma-sass \
+        compass-importer \
+        del \
+        eslint \
+        glob \
+        gulp \
+        gulp-concat \
+        gulp-eslint \
+        gulp-if \
+        gulp-sass \
+        gulp-sass-lint \
+        gulp-sourcemaps \
+        gulp-uglify \
+        gulp.spritesmith \
+        LPGhatguy/node-sass-glob \
+        normalize-scss \
+        sass-rem \
+        sass-toolkit \
+        script-loader \
+        susy \
+        typey \
+        yargs \
+        node-sass-asset-functions && \
+     apk del --purge make g++ python git
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["gulp"]

--- a/d7/README.md
+++ b/d7/README.md
@@ -1,0 +1,4 @@
+Dockerfile for Drupal Skilld d7 base theme.
+
+Usage (inside Makefile) `docker run --rm -it -v $(pwd):/work -u www-data:www-data skilldlabs/frontend:d7`
+

--- a/d7/docker-entrypoint.sh
+++ b/d7/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# prevent conflicts with existing
+rm -rf node_modules
+
+/usr/bin/npm link \
+    node-sass \
+    webpack \
+    webpack-dev-server \
+    webpack-stream \
+    babel-core \
+    babel-loader \
+    babel-plugin-transform-runtime \
+    babel-polyfill \
+    babel-preset-es2015 \
+    breakpoint-sass \
+    chroma-sass \
+    compass-importer \
+    del \
+    eslint \
+    gulp \
+    glob \
+    gulp-concat \
+    gulp-eslint \
+    gulp-if \
+    gulp-sass \
+    gulp-sass-lint \
+    gulp-sourcemaps \
+    gulp-uglify \
+    gulp.spritesmith \
+    node-sass-glob \
+    normalize-scss \
+    sass-rem \
+    sass-toolkit \
+    script-loader \
+    susy \
+    typey \
+    yargs \
+    node-sass-asset-functions
+
+exec "$@"


### PR DESCRIPTION
Everything works except `node-sass-asset-functions` (works outside docker) but this is something really simple, so maybe it's better to write our own as it won't take long and the logic isn't hard. This is required for the ruby/compass migration.

Will continue on this tomorrow, creating PR anyway as `node-sass-asset-functions` is not always required anyway, so the container can be used and the rest can be reviewed.