### PR TITLE
Package.json management added. Yarn included.

### DIFF
--- a/zen/Dockerfile
+++ b/zen/Dockerfile
@@ -1,32 +1,27 @@
-FROM skilldlabs/frontend:latest
+FROM mhart/alpine-node:7
 
 MAINTAINER Andy Postnikov
 
-ENV NPM_PACKAGES "bower \
-  breakpoint-sass \
-  browser-sync \
-  chroma-sass \
-  del \
-  eslint \
-  event-stream \
-  gulp-autoprefixer \
-  gulp-eslint \
-  gulp-if \
-  gulp-load-plugins \
-  gulp-rename \
-  gulp-replace \
-  gulp-sass-lint \
-  gulp-size \
-  gulp-sourcemaps \
-  gulp.spritesmith \
-  kss \
-  node-sass-import-once \
-  sass-lint \
-  support-for \
-  typey \
-  zen-grids"
+VOLUME /work
+WORKDIR /work
 
-RUN apk add --no-cache git \
-  && npm install -g $NPM_PACKAGES
+RUN apk add --no-cache make g++ python git
+RUN apk add --no-cache curl && \
+  mkdir -p /opt && \
+  curl -sL https://yarnpkg.com/latest.tar.gz | tar xz -C /opt && \
+  mv /opt/dist /opt/yarn && \
+  ln -s /opt/yarn/bin/yarn /usr/local/bin && \
+  apk del --purge curl
 
 COPY docker-entrypoint.sh /usr/bin/
+
+RUN cd /opt
+ADD https://raw.githubusercontent.com/skilld-labs/zen/8.x-7.x/STARTERKIT/package.json .
+RUN yarn config set cache-folder /opt/.yarn-cache
+RUN yarn install -g --cache-folder /opt/.yarn-cache
+RUN rm package.json
+
+
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["yarn", "run", "gulp"]

--- a/zen/docker-entrypoint.sh
+++ b/zen/docker-entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-# prevent conflicts with existing
-rm -rf node_modules
-
-/usr/bin/npm link gulp gulp-sass $NPM_PACKAGES
+yarn install --check-files --ignore-optional --ignore-platform --cache-folder /opt/.yarn-cache
+export PATH="$PATH:`yarn global bin`"
 
 exec "$@"


### PR DESCRIPTION

# What that commit about:

We have several issues with current npm docker-frontend build:
- List of packages is hard fixed and unversioned.
    ```sh
    ENV NPM_PACKAGES "bower \
      breakpoint-sass \
      browser-sync \
      ... 
      typey \
      zen-grids"
    ```
- If we want to add any new module to any project we have to update docker-frontend repo and its docker hub. 
- Current build not uses package.json from project and not uses package.json from [Zen](https://github.com/skilld-labs/zen/blob/8.x-7.x/STARTERKIT/package.json)
- If we plan to move to bowerless projects and use only node modules this build became useless. 


# What has been done here?

- Npm changed to [Yarn](https://yarnpkg.com/en/). It anounced as npm on steroids. https://www.sitepoint.com/yarn-vs-npm/ It is faster, has a lot of packaging features. But main reason of yarn: I couldn't do next things with npm. Maybe anyone can. 
- Instead of hardfixed list i'm using:
  ```sh
  ADD https://raw.githubusercontent.com/skilld-labs/zen/8.x-7.x/STARTERKIT/package.json .
  ```
  It seems good to use last version of modules. And actual list.
- Once installed module uses yarn caching.
- If project's package.json has any different modules inside then docker-entrypoint it will add required on first run. next time it will use cache. 
```sh
//second run
$ n
yarn install v0.22.0
[1/4] Resolving packages...
success Already up-to-date.
Done in 1.06s.
yarn run v0.22.0
$ "/work/node_modules/.bin/gulp"
[09:01:08] Using gulpfile /work/gulpfile.js
[09:01:08] Starting 'clean:css'...
[09:01:08] Starting 'clean:styleguide'...
``` 
- Build not uses docker-frontend:latest now and became standalone for testing purposes.

# How to test?

1. `cd zen` 
2. `docker build -t front .`
3. `cd anyproject_theme` 
4. `alias n='docker run -p 3000:3000 -p 3001:3001 --rm -it -v $(pwd):/work front '` 
5. `n` 
6. If all ok add to anyproject_theme's package.json any new modules. Via npm, yarn or even copypaste from [that commit](https://github.com/xArturia/zen/blob/672784a95b44950e52965eb4195b8494ce03f046/STARTERKIT/package.json).
7. Repeat step 5) 

# Main thing here.

This is obviously not a final build. Just a mix of different ideas. Build became slower but smarter. Yarn has a lot of new [features](https://yarnpkg.com/en/docs/cli/). Or we can find similar on npm and make it work. Anyway we have a lot of space to make it faster. Please test it well. Thanks