### PR TITLE
Added yarn managed universal image

### DIFF
--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -1,0 +1,17 @@
+FROM mhart/alpine-node:8.2.1
+
+
+RUN apk add --no-cache make g++ python git
+
+WORKDIR /vendor
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ADD https://raw.githubusercontent.com/skilld-labs/zen/8.x-7.x/STARTERKIT/package.json /vendor
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
+  && cd /vendor \
+  && yarn install --ignore-scripts
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["yarn", "run", "gulp"]

--- a/yarn/Makefile
+++ b/yarn/Makefile
@@ -1,0 +1,34 @@
+IMAGE_FRONT ?= iberdinsky/yarn-swiss-knife
+
+# Get local yarn cache dir
+# if yarn installed locally.
+YARN_VERSION := $(shell yarn --version 2>/dev/null)
+ifdef YARN_VERSION
+YARN_CACHE= -v $(shell yarn cache dir):/root/.yarn-cache
+else
+YARN_CACHE=
+endif
+
+
+front = docker run --rm  -it -v $(shell pwd):/work $(YARN_CACHE) $(IMAGE_FRONT) ${1}
+
+all: | run_once
+
+run_once:
+	make front
+	make clean
+
+front:
+	@echo "Building front tasks..."
+	docker pull $(IMAGE_FRONT)
+	$(call front)
+
+exec:
+	$(call front, sh)
+
+task:
+	$(call front, yarn run)
+
+clean:
+	rm -rf node_modules
+	rm -rf yarn.lock

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,0 +1,4 @@
+# yarn-swiss-knife
+
+Put Makefile in folder contains package.json
+Run `make`

--- a/yarn/docker-entrypoint.sh
+++ b/yarn/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+cd /work/
+
+# Simple copy until https://github.com/yarnpkg/yarn/issues/3724 will resolved
+# later in install should be added: `--modules-folder /vendor/node_modules`
+
+if [ ! -d /work/node_modules ]; then
+  cp -r /vendor/node_modules /work/node_modules
+fi
+
+yarn install --check-files --non-interactive --cache-folder /root/.yarn-cache
+exec "$@"


### PR DESCRIPTION
This build can work in any current and next project. 
For now i added image in own docker hub for testing. 
Build works a bit slower than it should because of current yarn issues. 
We may change this to npm. 
If yarn installed locally build will take modules from local cache folder. 
