### PR TITLE
Docker image for project-based approach

### DIFF
--- a/project-based/Dockerfile
+++ b/project-based/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:8-alpine
+
+MAINTAINER Pablo Guerino
+
+VOLUME /work
+WORKDIR /work
+
+ENV HOME "/tmp"
+ENV PACKAGES "g++ git python2 make"
+
+ADD package.json /
+
+RUN mkdir /fake-home && \
+    chmod 777 /fake-home & \
+    apk add --no-cache $PACKAGES && \
+    cd / && \
+    npm config set python /usr/bin/python && \
+    npm install && \
+    npm install -g gulp && \
+    apk del --no-cache --purge $PACKAGES
+
+COPY docker-entrypoint.sh /usr/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["npm", "run", "build"]

--- a/project-based/Dockerfile
+++ b/project-based/Dockerfile
@@ -11,13 +11,14 @@ ENV PACKAGES "g++ git python2 make"
 ADD package.json /
 
 RUN mkdir /fake-home && \
-    chmod 777 /fake-home & \
-    apk add --no-cache $PACKAGES && \
-    cd / && \
+    chmod 777 /fake-home && \
+    mv /package.json /fake-home && \
+    apk add --no-cache --virtual dependencies $PACKAGES && \
+    cd /fake-home && \
     npm config set python /usr/bin/python && \
     npm install && \
     npm install -g gulp && \
-    apk del --no-cache --purge $PACKAGES
+    apk del --no-cache --purge dependencies
 
 COPY docker-entrypoint.sh /usr/bin/
 

--- a/project-based/Makefile
+++ b/project-based/Makefile
@@ -1,0 +1,11 @@
+PROJECT = skilld/localtest
+GITLAB = xxxxxxxxxxx
+
+login:
+	docker login $(GITLAB)
+
+build:
+	docker build -t $(GITLAB)$(PROJECT) . --no-cache
+
+push:
+	docker push $(GITLAB)$(PROJECT)

--- a/project-based/README.md
+++ b/project-based/README.md
@@ -1,0 +1,25 @@
+# Dockerfile for Zen Theme.
+
+### Usage (Without Makefile)
+
+```
+docker run --rm -t -u 1000:1000 -v $(pwd):/work abc/xyz 
+```
+
+### Steps to build a new image
+
+_Note: this is just a quick guide to get started using this new image_
+
+- Login to gitlab so we can use gitlab registry `make login` or `docker login ...`
+- Use the same `package.json` as the one located inside the project repo 
+- You can set a project name in the `Makefile`
+- Build the container with `make build` 
+- Push it to gitlab with `make push`
+- Update the `.env` file from your project to use this new image
+
+### Why this image instead of the other ones?
+
+- Based on node.js 8.x
+- Easier to mantain: doesn't require packages to be hardcoded in the Dockerfile, we only mantain one package.json
+- Alternative way for caching (npm packages), we don't use global npm packages or links anymore
+- Backwards compatible

--- a/project-based/docker-entrypoint.sh
+++ b/project-based/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export HOME=/fake-home
+
+rm -rf /work/node_modules
+cp -rf /node_modules /work
+
+exec "$@"

--- a/project-based/docker-entrypoint.sh
+++ b/project-based/docker-entrypoint.sh
@@ -3,6 +3,6 @@
 export HOME=/fake-home
 
 rm -rf /work/node_modules
-cp -rf /node_modules /work
+cp -rf /fake-home/node_modules /work
 
 exec "$@"

--- a/project-based/package.json
+++ b/project-based/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "skilld-theme",
+  "author": "skilld.fr",
+  "description": "Theme for Skilld",
+  "version": "1.0.0",
+  "repository": {},
+  "devDependencies": {
+    "babel-core": "^6.24.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-es2015": "^6.24.0",
+    "breakpoint-sass": "^2.7.0",
+    "browser-sync": "^2.12.3",
+    "chroma-sass": "^1.2.4",
+    "del": "^2.2.0",
+    "eslint": "^2.9.0",
+    "font-awesome": "^4.7.0",
+    "gulp": "^3.9.1",
+    "gulp-autoprefixer": "^3.1.0",
+    "gulp-cached": "^1.1.0",
+    "gulp-eslint": "^2.0.0",
+    "gulp-if": "^2.0.0",
+    "gulp-load-plugins": "^1.2.2",
+    "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.4",
+    "gulp-sass": "2.3.1",
+    "gulp-sass-lint": "^1.1.1",
+    "gulp-size": "^2.1.0",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp.spritesmith": "^6.4.0",
+    "icheck": "^1.0.2",
+    "kss": "^3.0.0-beta.14",
+    "node-sass-import-once": "^1.2.0",
+    "sass-lint": "^1.7.0",
+    "script-loader": "^0.7.0",
+    "selectize": "^0.12.4",
+    "slick-carousel": "^1.7.1",
+    "support-for": "^1.0.6",
+    "typey": "^1.0.0",
+    "webpack": "^3.0.0",
+    "webpack-stream": "^3.2.0",
+    "zen-grids": "^2.0.3"
+  },
+  "engines": {
+    "node": ">=6.0.0"
+  },
+  "private": true,
+  "scripts": {
+    "build": "NODE_ENV=production gulp",
+    "dev": "NODE_ENV=dev gulp"
+  }
+}


### PR DESCRIPTION
### Usage (Without Makefile)

```
docker run --rm -t -u 1000:1000 -v $(pwd):/work abc/xyz 
```

### Steps to build a new image

_Note: this is just a quick guide to get started using this new image_

- Login to gitlab so we can use gitlab registry `make login` or `docker login ...`
- Use the same `package.json` as the one located inside the project repo 
- You can set a project name in the `Makefile`
- Build the container with `make build` 
- Push it to gitlab with `make push`
- Update the `.env` file from your project to use this new image

### Why this image instead of the other ones?

- Based on node.js 9.x
- Easier to mantain: doesn't require packages to be hardcoded in the Dockerfile, we only mantain one package.json
- Alternative way for caching (npm packages), we don't use global npm packages or links anymore
- Backwards compatible